### PR TITLE
Support transient attributes as a first class citizen

### DIFF
--- a/factori-impl/src/define.rs
+++ b/factori-impl/src/define.rs
@@ -179,6 +179,10 @@ impl Parse for Definition {
       }
     }
 
+    if transient.is_some() && builder.is_none() {
+      return Err(inner.error("transient attributes require a builder {} block"));
+    }
+
     let default = default.ok_or_else(|| inner.error("missing default {} block"))?;
 
     Ok(Self {

--- a/factori-impl/src/define.rs
+++ b/factori-impl/src/define.rs
@@ -111,14 +111,13 @@ impl Parse for TransientBlock {
         break;
       }
 
-      // parse a: type = value
+      // parse a: type = value and  take ending , if there
       fields.push(inner.parse()?); // a
       inner.parse::<Token![:]>()?; // :
-      types.push(inner.parse()?); // type
+      types.push(inner.parse()?);  // type
       inner.parse::<Token![=]>()?; // =
       values.push(inner.parse()?); // value
-      // consume , if there
-      if inner.peek(Token![,]) {
+      if inner.peek(Token![,]) {   // maybe ,
         inner.parse::<Token![,]>()?;
       }
     }

--- a/tests/transient.rs
+++ b/tests/transient.rs
@@ -7,17 +7,41 @@ pub struct User {
 
 factori!(User, {
   default {
-    name = "Richard".to_string(),
+    name: String = "Richard".to_string()
   }
 
   transient {
-    upcased: bool = false,
+    upcased: bool = false
+  }
+
+  mixin upcased {
+    upcased = true
+  }
+
+  builder {
+    let name = if upcased { name.to_uppercase() } else { name };
+    User { name }
   }
 });
+
 
 #[test]
 fn transient_doesnt_change_anything() {
   let user = create!(User, name: "John".into());
 
   assert_eq!(user.name, "John");
+}
+
+#[test]
+fn transient_changes_value() {
+  let user = create!(User, upcased: true);
+
+  assert_eq!(user.name, "RICHARD");
+}
+
+#[test]
+fn transient_works_with_mixins() {
+  let user = create!(User, :upcased);
+
+  assert_eq!(user.name, "RICHARD");
 }

--- a/tests/transient.rs
+++ b/tests/transient.rs
@@ -1,0 +1,23 @@
+#[macro_use]
+extern crate factori;
+
+pub struct User {
+  name: String,
+}
+
+factori!(User, {
+  default {
+    name = "Richard".to_string(),
+  }
+
+  transient {
+    upcased: bool = false,
+  }
+});
+
+#[test]
+fn transient_doesnt_change_anything() {
+  let user = create!(User, name: "John".into());
+
+  assert_eq!(user.name, "John");
+}


### PR DESCRIPTION
## What

Adds support for transient attributes, transient attributes are attributes that can be used in the factory builder block
but are not actually part of the struct being created.

This allows to factories a bit more powerful


- Adds a `transient {}` block to `factori!()` to capture transient attributes, see `tests/transient.rs` for complete info
- Transient attributes can be set in mixins
- Requires that `builder {}` block is present

```rust
pub struct User {
  name: String,
}

factori!(User, {
  default {
    name: String = "Richard".to_string()
  }
  transient {
    upcased: bool = false
  }
  builder {
    let name = if upcased { name.to_uppercase() } else { name };
    User { name }
  }
}
```

## Why

This PR makes transient attributes explicit in the factory declaration, In factori you could already functionally do transient attributes,

```rust
struct User {
  name: String,
}

factori(User, {
  default {
    name: "John".into(),
    // transient
    upcase: false,
  }

  builder {
    let name = if upcase { name.to_uppercase() } else { name };
    User { name }
  }
});

// somewhere else
create(User, upcase: true);
```

but knowing which fields are actually part of the struct and which aren't is non-obvious in many cases:

- if your factories don't live next to the struct
- if your factories are complex
- etc...


