### PR TITLE
Topic/add support for nested structs

### DIFF
--- a/factori-imp-impl/Cargo.toml
+++ b/factori-imp-impl/Cargo.toml
@@ -15,5 +15,4 @@ proc-macro = true
 [dependencies]
 proc-macro2 = "1.0"
 quote = "1.0"
-syn = "1.0"
-
+syn = { version = "1.0", features = ["full"] }

--- a/tests/simple.rs
+++ b/tests/simple.rs
@@ -7,7 +7,7 @@ pub struct Vehicle {
 }
 
 pub struct Garage {
-    vehicle: Vehicle,
+    vehicle: Vec<Vehicle>,
 }
 
 factori!(Vehicle, {
@@ -31,7 +31,7 @@ factori!(Vehicle, {
 
 factori!(Garage, {
     default {
-        vehicle = create!(Vehicle)
+        vehicle = vec![create!(Vehicle)]
     }
 });
 
@@ -45,8 +45,9 @@ fn simple_struct() {
 #[test]
 fn nested_struct() {
     let default = create!(Garage);
-    assert_eq!(default.vehicle.number_wheels, 4);
-    assert_eq!(default.vehicle.electric, false);
+    assert_eq!(default.vehicle.len(), 1);
+    assert_eq!(default.vehicle[0].number_wheels, 4);
+    assert_eq!(default.vehicle[0].electric, false);
 }
 
 #[test]

--- a/tests/simple.rs
+++ b/tests/simple.rs
@@ -6,6 +6,10 @@ pub struct Vehicle {
   electric: bool,
 }
 
+pub struct Garage {
+    vehicle: Vehicle,
+}
+
 factori!(Vehicle, {
   default {
       number_wheels = 4,
@@ -25,11 +29,24 @@ factori!(Vehicle, {
   }
 });
 
+factori!(Garage, {
+    default {
+        vehicle = create!(Vehicle)
+    }
+});
+
 #[test]
 fn simple_struct() {
   let default = create!(Vehicle);
   assert_eq!(default.number_wheels, 4);
   assert!(!default.electric);
+}
+
+#[test]
+fn nested_struct() {
+    let default = create!(Garage);
+    assert_eq!(default.vehicle.number_wheels, 4);
+    assert_eq!(default.vehicle.electric, false);
 }
 
 #[test]


### PR DESCRIPTION
Hello, would you consider merging my pull request?

Enabling the `full` feature of `syn` lets you use macros inside of the factories. Then you can use `create!` inside `create!`.